### PR TITLE
Expose Arpeggiator Swing in UI and centralize arp length clamping

### DIFF
--- a/10_Source_code/Core/menus/Inc/_menu_controller.h
+++ b/10_Source_code/Core/menus/Inc/_menu_controller.h
@@ -11,7 +11,15 @@
 #include "memory_main.h"   // for save_field_t, SAVE_FIELD_COUNT, etc.
 #include "menus.h" // for menu_list_t, CtrlActiveList, list_for_page
 
+#define ARP_STEP_BITS_COUNT 8u
 
+static inline uint8_t arp_length_clamped(void)
+{
+    uint8_t len = (uint8_t)save_get(ARPEGGIATOR_LENGTH);
+    if (len < 1u) len = 1u;
+    if (len > ARP_STEP_BITS_COUNT) len = ARP_STEP_BITS_COUNT;
+    return len;
+}
 
 // ---------------------
 // UI submenu id
@@ -110,12 +118,8 @@ static inline uint8_t menu_field_row_span(save_field_t f)
         case SETTINGS_FILTERED_CH:
             return 16u;
 
-        case ARPEGGIATOR_NOTES: {
-            uint8_t len = (uint8_t)save_get(ARPEGGIATOR_LENGTH);
-            if (len < 1u) len = 1u;
-            if (len > 8u) len = 8u;
-            return len;
-        }
+        case ARPEGGIATOR_NOTES:
+            return arp_length_clamped();
 
         default:
             return 1u;

--- a/10_Source_code/Core/menus/Src/_menu_controller.c
+++ b/10_Source_code/Core/menus/Src/_menu_controller.c
@@ -19,6 +19,7 @@ uint32_t s_field_change_bits[CHANGE_BITS_WORDS] = {0};
 
 static volatile uint8_t s_ui_reload = 0;
 
+
 // -------------------------
 // Encoder & value helpers (logic-agnostic)
 // -------------------------
@@ -101,9 +102,7 @@ void update_bits_8_steps(save_field_t field)
     const int8_t bit = ui_selected_bit(field);
     if (bit < 0) return;
 
-    uint8_t len = (uint8_t)save_get(ARPEGGIATOR_LENGTH);
-    if (len < 1u) len = 1u;
-    if (len > 8u) len = 8u;
+    const uint8_t len = arp_length_clamped();
 
     // Don’t allow edits beyond length
     if ((uint8_t)bit >= len) return;
@@ -153,7 +152,8 @@ const menu_controls_t menu_controls[SAVE_FIELD_COUNT] = {
     MC(ARPEGGIATOR_OCTAVES,            WRAP,  update_value_inc1,            CTRL_ARPEGGIATOR_PAGE_1),
     MC(ARPEGGIATOR_PATTERN,            WRAP,  update_value_inc1,            CTRL_ARPEGGIATOR_PAGE_1),
 
-    MC(ARPEGGIATOR_LENGTH,          NO_WRAP,  update_value_inc10,            CTRL_ARPEGGIATOR_PAGE_2),
+    MC(ARPEGGIATOR_SWING,           NO_WRAP, update_value_inc1,             CTRL_ARPEGGIATOR_PAGE_2),
+    MC(ARPEGGIATOR_LENGTH,          NO_WRAP, update_value_inc10,            CTRL_ARPEGGIATOR_PAGE_2),
     MC(ARPEGGIATOR_NOTES,              WRAP, update_bits_8_steps,           CTRL_ARPEGGIATOR_PAGE_2),
 	MC(ARPEGGIATOR_HOLD,               WRAP,  update_value_inc1,            CTRL_ARPEGGIATOR_PAGE_2),
 	MC(ARPEGGIATOR_KEY_SYNC,           WRAP,  update_value_inc1,            CTRL_ARPEGGIATOR_PAGE_2),

--- a/10_Source_code/Core/menus/Src/_menu_ui.c
+++ b/10_Source_code/Core/menus/Src/_menu_ui.c
@@ -119,9 +119,7 @@ static void menu_ui_draw_8_steps(const ui_element *e)
     const uint32_t     mask = (uint32_t)save_get(f);
     const int8_t       selb = ui_selected_bit(f);
 
-    uint8_t len = (uint8_t)save_get(ARPEGGIATOR_LENGTH);
-    if (len < 1u) len = 1u;
-    if (len > 8u) len = 8u;
+    const uint8_t len = arp_length_clamped();
 
     const int16_t base_x = (int16_t)e->x;
     const int16_t y      = (int16_t)e->y;

--- a/10_Source_code/Core/menus/Src/menu_arpeggiator.c
+++ b/10_Source_code/Core/menus/Src/menu_arpeggiator.c
@@ -9,6 +9,13 @@
 #include "menus.h"
 #include "text.h"
 
+#define ARP_CENTER_SPLIT_X 62
+#define ARP_GATE_X 35
+#define ARP_SWING_X 35
+#define ARP_HOLD_X 35
+#define ARP_KEY_SYNC_LABEL_X 60
+#define ARP_KEY_SYNC_VALUE_X 110
+
 void cont_update_arpeggiator(menu_list_t field) {
 	toggle_subpage(field);
 }
@@ -16,37 +23,35 @@ void cont_update_arpeggiator(menu_list_t field) {
 
 void ui_update_arpeggiator(void)
 {
-    #define CENTER_SPLIT 62
-
     const ui_element elems[] = {
         // type       save_item               text                          font    x             y        ctrl_group_id
         { ELEM_TEXT , 0,                      TEXT_(arpeggiator_1),         UI_6x8, TXT_LEFT,     LINE_0,  CTRL_ARPEGGIATOR_PAGE_1 },
 
         // Tempo
         { ELEM_TEXT , 0,                      TEXT_(tempo),                 UI_6x8, TXT_LEFT,     LINE_1,  CTRL_ARPEGGIATOR_PAGE_1 },
-        { ELEM_ITEM , TEMPO_CURRENT_TEMPO,    TEXT_(zer_to_300),            UI_6x8, CENTER_SPLIT, LINE_1,  CTRL_SHARED_TEMPO      },
+        { ELEM_ITEM , TEMPO_CURRENT_TEMPO,    TEXT_(zer_to_300),            UI_6x8, ARP_CENTER_SPLIT_X, LINE_1,  CTRL_SHARED_TEMPO      },
 
         // Division
         { ELEM_TEXT , 0,                      TEXT_(division_),              UI_6x8, TXT_LEFT,     LINE_2,  CTRL_ARPEGGIATOR_PAGE_1 },
-        { ELEM_ITEM , ARPEGGIATOR_DIVISION,   TEXT_(division_list),         UI_6x8, CENTER_SPLIT, LINE_2,  CTRL_ARPEGGIATOR_PAGE_1 },
+        { ELEM_ITEM , ARPEGGIATOR_DIVISION,   TEXT_(division_list),         UI_6x8, ARP_CENTER_SPLIT_X, LINE_2,  CTRL_ARPEGGIATOR_PAGE_1 },
 
         // Gate
         { ELEM_TEXT , 0,                      TEXT_(gate_),                  UI_6x8, TXT_LEFT,     LINE_3,  CTRL_ARPEGGIATOR_PAGE_1 },
-        { ELEM_ITEM , ARPEGGIATOR_GATE,       TEXT_(ten_hundred_ten_percent), UI_6x8, 35,         LINE_3,  CTRL_ARPEGGIATOR_PAGE_1 },
-        { ELEM_ITEM , ARPEGGIATOR_OCTAVES,    TEXT_(octave_count),          UI_6x8, CENTER_SPLIT, LINE_3,  CTRL_ARPEGGIATOR_PAGE_1 },
+        { ELEM_ITEM , ARPEGGIATOR_GATE,       TEXT_(ten_hundred_ten_percent), UI_6x8, ARP_GATE_X, LINE_3,  CTRL_ARPEGGIATOR_PAGE_1 },
+        { ELEM_ITEM , ARPEGGIATOR_OCTAVES,    TEXT_(octave_count),          UI_6x8, ARP_CENTER_SPLIT_X, LINE_3,  CTRL_ARPEGGIATOR_PAGE_1 },
 
         // Pattern
         { ELEM_TEXT , 0,                      TEXT_(pattern_),               UI_6x8, TXT_LEFT,     LINE_4,  CTRL_ARPEGGIATOR_PAGE_1 },
-        { ELEM_ITEM , ARPEGGIATOR_PATTERN,    TEXT_(arp_patterns),          UI_6x8, CENTER_SPLIT, LINE_4,  CTRL_ARPEGGIATOR_PAGE_1 },
+        { ELEM_ITEM , ARPEGGIATOR_PATTERN,    TEXT_(arp_patterns),          UI_6x8, ARP_CENTER_SPLIT_X, LINE_4,  CTRL_ARPEGGIATOR_PAGE_1 },
 
         // Page 2
         { ELEM_TEXT , 0,                      TEXT_(arpeggiator_2),         UI_6x8, TXT_LEFT,     LINE_0,  CTRL_ARPEGGIATOR_PAGE_2 },
 
         { ELEM_TEXT , 0,                      TEXT_(swing_),                 UI_6x8, TXT_LEFT,     LINE_1,  CTRL_ARPEGGIATOR_PAGE_2 },
-		//Romain insert swing logic here
+        { ELEM_ITEM , ARPEGGIATOR_SWING,      TEXT_(zer_to_300),             UI_6x8, ARP_SWING_X, LINE_1,  CTRL_ARPEGGIATOR_PAGE_2 },
 
         { ELEM_TEXT , 0,                      TEXT_(length_),       UI_6x8, TXT_LEFT,     LINE_2,  CTRL_ARPEGGIATOR_PAGE_2 },
-        { ELEM_ITEM , ARPEGGIATOR_LENGTH,     TEXT_(zer_to_300),    UI_6x8, CENTER_SPLIT, LINE_2,  CTRL_ARPEGGIATOR_PAGE_2 },
+        { ELEM_ITEM , ARPEGGIATOR_LENGTH,     TEXT_(zer_to_300),    UI_6x8, ARP_CENTER_SPLIT_X, LINE_2,  CTRL_ARPEGGIATOR_PAGE_2 },
 
 
 
@@ -56,9 +61,9 @@ void ui_update_arpeggiator(void)
 
 
         { ELEM_TEXT , 0,                      TEXT_(hold_),                 UI_6x8, TXT_LEFT,     LINE_4,  CTRL_ARPEGGIATOR_PAGE_2 },
-        { ELEM_ITEM , ARPEGGIATOR_HOLD,       TEXT_(off_on),                UI_6x8, 35,           LINE_4,  CTRL_ARPEGGIATOR_PAGE_2 },
-        { ELEM_TEXT , 0,                      TEXT_(key_sync_),             UI_6x8, 60,           LINE_4,  CTRL_ARPEGGIATOR_PAGE_2 },
-        { ELEM_ITEM , ARPEGGIATOR_KEY_SYNC,   TEXT_(off_on),                UI_6x8, 110,         LINE_4,  CTRL_ARPEGGIATOR_PAGE_2 },
+        { ELEM_ITEM , ARPEGGIATOR_HOLD,       TEXT_(off_on),                UI_6x8, ARP_HOLD_X,  LINE_4,  CTRL_ARPEGGIATOR_PAGE_2 },
+        { ELEM_TEXT , 0,                      TEXT_(key_sync_),             UI_6x8, ARP_KEY_SYNC_LABEL_X, LINE_4,  CTRL_ARPEGGIATOR_PAGE_2 },
+        { ELEM_ITEM , ARPEGGIATOR_KEY_SYNC,   TEXT_(off_on),                UI_6x8, ARP_KEY_SYNC_VALUE_X, LINE_4,  CTRL_ARPEGGIATOR_PAGE_2 },
 
 
     };


### PR DESCRIPTION
### Motivation
- Make the arpeggiator Swing editable from the menu and ensure swing cannot be set to 0 by respecting existing save limits. 
- Reduce duplicated clamping logic for arpeggiator step length across controller and UI code for easier maintenance. 
- Small controller/UI cleanup to centralize layout tuning for arpeggiator-related elements.

### Description
- Added `ARP_STEP_BITS_COUNT` and a shared helper `arp_length_clamped()` in `_menu_controller.h` to centralize arp length limits. 
- Replaced duplicated length-clamp code with `arp_length_clamped()` in `menu_field_row_span()`, `update_bits_8_steps()` and `menu_ui_draw_8_steps()` so drawing, editing and row-span logic use the same limit. 
- Exposed `ARPEGGIATOR_SWING` in the arpeggiator page 2 UI by adding the `ELEM_ITEM` for swing and defining `ARP_SWING_X`, and wired `ARPEGGIATOR_SWING` into the `menu_controls` table so encoder edits work. 
- Introduced named `ARP_*` X-position constants in `menu_arpeggiator.c` (e.g., `ARP_CENTER_SPLIT_X`, `ARP_GATE_X`, `ARP_SWING_X`, `ARP_HOLD_X`, `ARP_KEY_SYNC_LABEL_X`, `ARP_KEY_SYNC_VALUE_X`) to centralize layout values.

### Testing
- Ran text/identity searches (`rg`) for `ARPEGGIATOR_SWING`, `arp_length_clamped`, and `ARP_STEP_BITS_COUNT` to confirm symbols are present and referenced (succeeded). 
- Inspected the produced diff via `git diff` to verify intended file changes (succeeded). 
- Added and committed the modified files with a local commit and validated recent `git log` output to confirm the change landed (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcffa8f7c832fba9d8ade92241aba)