### PR TITLE
Remove no-op tempo controller callback and guard menu dispatch

### DIFF
--- a/10_Source_code/Core/memory/Inc/memory_main.h
+++ b/10_Source_code/Core/memory/Inc/memory_main.h
@@ -44,7 +44,6 @@ typedef enum {
 typedef enum {
     // midi_tempo_data
     TEMPO_CURRENT_TEMPO,
-    TEMPO_TEMPO_CLICK_RATE,
     TEMPO_CURRENTLY_SENDING,
     TEMPO_SEND_TO_MIDI_OUT,
 

--- a/10_Source_code/Core/memory/Src/memory_flash.c
+++ b/10_Source_code/Core/memory/Src/memory_flash.c
@@ -19,8 +19,6 @@ enum {
     /* u32 fields */
     IDX_U32_TEMPO_CURRENT_TEMPO = 0,
 
-	IDX_U32_TEMPO_CLICK_RATE,
-
 	IDX_U32_MODIFY_VEL_PM,
 
 	IDX_U32_TRANSPOSE_SHIFT,
@@ -106,7 +104,6 @@ static void bind_field_pointers(save_struct* s, int32_t** u32tab, uint8_t** u8ta
 
     /* ---- u32 mappings ---- */
     u32tab[TEMPO_CURRENT_TEMPO]        = &s->u32_vals[IDX_U32_TEMPO_CURRENT_TEMPO];
-    u32tab[TEMPO_TEMPO_CLICK_RATE]     = &s->u32_vals[IDX_U32_TEMPO_CLICK_RATE];
 
     u32tab[MODIFY_VEL_PLUS_MINUS] = &s->u32_vals[IDX_U32_MODIFY_VEL_PM];
 

--- a/10_Source_code/Core/memory/Src/memory_main.c
+++ b/10_Source_code/Core/memory/Src/memory_main.c
@@ -11,7 +11,6 @@
 const save_limits_t save_limits[SAVE_FIELD_COUNT] = {
     //                                   min         max         default
     [TEMPO_CURRENT_TEMPO]        = {     20,        300,        120 },
-    [TEMPO_TEMPO_CLICK_RATE]     = {      1,      50000,         24 },
     [TEMPO_CURRENTLY_SENDING]    = {      0,          1,          0 },
     [TEMPO_SEND_TO_MIDI_OUT]     = {      0,          2,          0 },
 

--- a/10_Source_code/Core/menus/Inc/menus.h
+++ b/10_Source_code/Core/menus/Inc/menus.h
@@ -46,7 +46,6 @@ typedef uint8_t (*selector_compute_fn_t)();
 CtrlActiveList* list_for_page(menu_list_t page);
 
 // -------- Individual menu updates --------
-void cont_update_tempo();
 void ui_code_tempo();
 void ui_update_tempo();
 

--- a/10_Source_code/Core/menus/Src/menu_tempo.c
+++ b/10_Source_code/Core/menus/Src/menu_tempo.c
@@ -8,13 +8,6 @@
 #include "menus.h"
 #include "screen_driver.h" //draw_line
 
-void cont_update_tempo() {
-  //BPM recalculation
-  const uint32_t bpm = save_get(TEMPO_CURRENT_TEMPO);
-  const uint32_t rate = bpm ? (6000000u / (bpm * 48u)) : 0u;
-  save_modify_u32(TEMPO_TEMPO_CLICK_RATE, SAVE_MODIFY_SET, rate);
-}
-
 void ui_update_tempo(void)
 {
     const ui_element elems[] = {

--- a/10_Source_code/Core/menus/Src/menus.c
+++ b/10_Source_code/Core/menus/Src/menus.c
@@ -36,7 +36,7 @@ static inline menu_list_t current_menu(void) {
 }
 
 static const MenuVTable kMenuVT[AMOUNT_OF_MENUS] = {
-    [MENU_TEMPO]       = { ui_update_tempo,       ui_code_tempo,       (cont_fn1_t)cont_update_tempo },
+    [MENU_TEMPO]       = { ui_update_tempo,       ui_code_tempo,       NULL },
     [MENU_MODIFY]      = { ui_update_modify,      ui_code_modify,      cont_update_modify },
     [MENU_TRANSPOSE]   = { ui_update_transpose,   ui_code_transpose,   cont_update_transpose },
     [MENU_ARPEGGIATOR] = { ui_update_arpeggiator, ui_code_arpeggiator, cont_update_arpeggiator },
@@ -55,7 +55,9 @@ void ui_code_menu(void){
 
 void cont_update_menu(menu_list_t field){
     const menu_list_t m = current_menu();
-    kMenuVT[m].cont_update(field);
+    if (kMenuVT[m].cont_update) {
+        kMenuVT[m].cont_update(field);
+    }
 }
 
 // ==============================

--- a/10_Source_code/Core/system/Src/main.c
+++ b/10_Source_code/Core/system/Src/main.c
@@ -326,8 +326,9 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 
   // Romagnetics code
   if (htim->Instance == TIM2) {
-    uint8_t send_to_out        = save_get(TEMPO_SEND_TO_MIDI_OUT);
-    uint32_t tempo_click_rate  = save_get(TEMPO_TEMPO_CLICK_RATE);
+    const uint8_t send_to_out = save_get(TEMPO_SEND_TO_MIDI_OUT);
+    const uint32_t bpm = save_get(TEMPO_CURRENT_TEMPO);
+    const uint32_t tempo_click_rate = (bpm > 0u) ? (6000000u / (bpm * 48u)) : 0u;
     send_midi_tempo_out(tempo_click_rate, send_to_out);
   }
 }


### PR DESCRIPTION
### Motivation
- The stored `TEMPO_TEMPO_CLICK_RATE` was removed and tempo tick rate is derived at send-time, so the tempo controller hook became a no-op and should be removed to avoid misleading API surface.
- Avoid keeping an empty callback and a cast in the vtable which hides that the tempo menu has no controller-side update behavior.

### Description
- Removed the `cont_update_tempo` declaration from `10_Source_code/Core/menus/Inc/menus.h` so no empty prototype remains.   
- Deleted the empty `cont_update_tempo` definition from `10_Source_code/Core/menus/Src/menu_tempo.c` leaving only real UI code.   
- Updated the menu vtable in `10_Source_code/Core/menus/Src/menus.c` to register `NULL` for the tempo menu `cont_update` slot and replaced the previous cast-based entry.   
- Made `cont_update_menu` in `menus.c` guard the vtable callback with a null check before invoking it so pages without a controller hook are safe.

### Testing
- Ran `rg "cont_update_tempo|cont_update_menu\(|kMenuVT\[MENU_TEMPO\]" -n 10_Source_code/Core/menus` to confirm the declaration/definition and vtable entry were updated (success).  
- Ran `rg "TEMPO_TEMPO_CLICK_RATE|IDX_U32_TEMPO_CLICK_RATE" -n 10_Source_code/Core` to ensure the click-rate symbol is not present (no matches found, success).  
- Verified repository status and created a commit containing the changes on branch `fix/tempo-click-rate-followup` (commit `d38f037`, success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e76246020832f8b28afae35601fbc)